### PR TITLE
Type `SendFunction` generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'react-robot' {
     initialContext?: M['context']
   ): [
     M['state'] & {context: M['context']},
-    SendFunction<keyof M['context']>,
+    SendFunction<keyof M['states']>,
     Service<typeof machine>
   ];
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'react-robot' {
     initialContext?: M['context']
   ): [
     M['state'] & {context: M['context']},
-    SendFunction,
+    SendFunction<keyof M['context']>,
     Service<typeof machine>
   ];
 }


### PR DESCRIPTION
If we pass a type to the `SendFunction`, we can get type hints for our `send()` calls.

<img width="366" alt="CleanShot 2022-12-29 at 14 10 59@2x" src="https://user-images.githubusercontent.com/967145/209906211-e5730a82-15ac-4491-910c-ddb84b2f3e52.png">
